### PR TITLE
Fix file descriptor leak when getting stats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-alpine3.17 AS base
+FROM golang:1.24.3-alpine3.22 AS base
 
 RUN adduser -D -H docker-exporter
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -273,6 +273,8 @@ func (c *DockerCollector) containerStats(ctx context.Context, containerID string
 		return nil, err
 	}
 
+	defer r.Body.Close()
+
 	var stats types.StatsJSON
 	decoder := json.NewDecoder(r.Body)
 


### PR DESCRIPTION
The docker client's ContainerStats method returns an io.Reader, with the note:

> It's up to the caller to close the io.ReadCloser returned.

Which wasn't happening here.

This causes issues when accessing Docker via a HTTP proxy, as it just constantly leaks a socket per container every time the metrics are collected. (I don't think it matters too much if accessing directly over the unix socket, or if the proxy is configured to shut down idle connections).

Before this change I was seeing the FD count for the exporter process increase by 40-50 every minute (and everything eventually stopped working when it hit the FD limit). Now it's stable over time.

Also update the version of Go in the Dockerfile, as it was behind the go.mod and wasn't happy building.