### PR TITLE
feat: expose configured container labels as a metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ scrape_configs:
 | `--auth-token`   | Optional auth token for the docker exporter server. If no token is set authentication is disabled.   |                          | `DOCKER_EXPORTER_AUTH_TOKEN`   |
 | `--log-level`    | Log level for the exporter.                                                                          | `info`                   | `DOCKER_EXPORTER_LOG_LEVEL`    |
 | `--ignore-label` | Set the label name for ignoring docker containers. (See [Ignoring Containers](#ignoring-containers)) | `docker-exporter.ignore` | `DOCKER_EXPORTER_IGNORE_LABEL` |
+| `--container-label` | Docker label to expose as a `docker_container_labels` metric. Repeatable. (See [Exposing Container Labels](#exposing-container-labels)) | | `DOCKER_EXPORTER_CONTAINER_LABELS` |
 
 ### Exported Metrics
 
@@ -71,6 +72,7 @@ scrape_configs:
 | docker_container_block_io_write_bytes       | Block I/O write bytes total        | name                    |
 | docker_container_cpu_usage_percentage       | CPU usage in percentage            | name                    |
 | docker_container_info                       | Infos about the container          | name, image_name, image |
+| docker_container_labels                     | Configured container labels (value 1)  | name, container_label_* |
 | docker_container_memory_total_bytes         | Total memory in bytes              | name                    |
 | docker_container_memory_usage_bytes         | Memory usage in bytes              | name                    |
 | docker_container_memory_usage_percentage    | Memory usage in percentage         | name                    |
@@ -99,6 +101,53 @@ services:
     labels:
       docker-exporter.ignore: "true"
 ```
+
+### Exposing Container Labels
+
+By default no container labels are exported. Selected labels are exposed on a
+dedicated `docker_container_labels` metric (value `1`), following the
+`kube_pod_labels` convention: the Docker label key is prefixed with
+`container_label_` and any character outside `[a-zA-Z0-9_]` becomes `_`. A
+series only carries the selected labels a container actually sets — absent
+labels are omitted, not exported empty.
+
+There are two ways to select labels, and they combine (union):
+
+1. **Globally**, for every container, via the `--container-label` flag
+   (repeatable) or a comma-separated `DOCKER_EXPORTER_CONTAINER_LABELS`
+   environment variable:
+
+   ```
+   $ docker-exporter --container-label com.docker.compose.project --container-label maintainer
+   ```
+
+2. **Per container**, by setting the `docker-exporter.exposed-labels` label to a
+   comma-separated list of that container's own label keys to expose:
+
+   ```yaml
+   services:
+     web:
+       image: nginx
+       labels:
+         docker-exporter.exposed-labels: "com.docker.compose.project,maintainer"
+   ```
+
+Either way the result is the same metric:
+
+```
+docker_container_labels{name="web",container_label_com_docker_compose_project="shop",container_label_maintainer="acme"} 1
+```
+
+Join labels onto other metrics in PromQL via the container `name`:
+
+```promql
+docker_container_cpu_usage_percentage
+  * on(name) group_left(container_label_com_docker_compose_project) docker_container_labels
+```
+
+> Exporting *all* labels is intentionally not offered. Labels are selected by an
+> explicit allowlist to keep metric cardinality bounded — note the per-container
+> option delegates that choice to whoever can set container labels.
 
 ## Contributing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,11 @@ var (
 			Value:   "docker-exporter.ignore",
 			Sources: cli.EnvVars("DOCKER_EXPORTER_IGNORE_LABEL"),
 		},
+		&cli.StringSliceFlag{
+			Name:    "container-label",
+			Usage:   "Docker label to expose as a `docker_container_labels` metric. Repeatable, or comma-separated via the environment variable.",
+			Sources: cli.EnvVars("DOCKER_EXPORTER_CONTAINER_LABELS"),
+		},
 	}
 )
 
@@ -87,7 +92,7 @@ func start(_ context.Context, cmd *cli.Command) error {
 		log.Info("authentication is enabled")
 	}
 
-	dc, err := collector.NewDockerCollector(clock.NewClock(), cmd.String("ignore-label"))
+	dc, err := collector.NewDockerCollector(clock.NewClock(), cmd.String("ignore-label"), cmd.StringSlice("container-label"))
 	if err != nil {
 		log.WithError(err).
 			Fatal("failed to create docker collector")

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -17,25 +17,34 @@ import (
 )
 
 type DockerCollector struct {
-	ignoreLabel string
-	client      *client.Client
-	clock       clock.Clock
+	ignoreLabel        string
+	client             *client.Client
+	clock              clock.Clock
+	containerLabelKeys []string
 }
 
-func NewDockerCollector(clk clock.Clock, ignoreLabel string) (*DockerCollector, error) {
+func NewDockerCollector(clk clock.Clock, ignoreLabel string, containerLabels []string) (*DockerCollector, error) {
 	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}
 
-	return NewWithClient(client, clk, ignoreLabel), nil
+	return NewWithClient(client, clk, ignoreLabel, containerLabels), nil
 }
 
-func NewWithClient(client *client.Client, clk clock.Clock, ignoreLabel string) *DockerCollector {
+func NewWithClient(client *client.Client, clk clock.Clock, ignoreLabel string, containerLabels []string) *DockerCollector {
+	keys := make([]string, 0, len(containerLabels))
+	for _, k := range containerLabels {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+
 	return &DockerCollector{
-		client:      client,
-		clock:       clk,
-		ignoreLabel: ignoreLabel,
+		client:             client,
+		clock:              clk,
+		ignoreLabel:        ignoreLabel,
+		containerLabelKeys: keys,
 	}
 }
 
@@ -98,6 +107,8 @@ func (c *DockerCollector) collectContainerMetrics(ctx context.Context, container
 		inspect.Config.Image,
 		inspect.Image,
 	)
+
+	c.collectContainerLabels(ch, name, container)
 
 	ch <- prometheus.MustNewConstMetric(
 		containerStateMetric, prometheus.GaugeValue, 1, name, container.State,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -60,7 +60,7 @@ func TestCollectMetrics(t *testing.T) {
 		Return(2 * time.Second).
 		Times(1)
 
-	dc := collector.NewWithClient(cli, mockClock, ignoreLabel)
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
 	# HELP docker_container_block_io_read_bytes Block I/O read bytes total
@@ -157,7 +157,7 @@ func TestCollectMetricsShouldCollectErrorWhenContainerListFails(t *testing.T) {
 		Return(2 * time.Second).
 		Times(1)
 
-	dc := collector.NewWithClient(cli, mockClock, ignoreLabel)
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
 	# HELP docker_exporter_scrape_errors Number of scrape errors
@@ -200,7 +200,7 @@ func TestCollectMetricsShouldCollectErrorWhenContainerInspectFails(t *testing.T)
 		Return(2 * time.Second).
 		Times(1)
 
-	dc := collector.NewWithClient(cli, mockClock, ignoreLabel)
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
 	# HELP docker_exporter_scrape_errors Number of scrape errors
@@ -257,7 +257,7 @@ func TestCollectMetricsShouldCollectErrorWhenContainerStatsFails(t *testing.T) {
 		Return(2 * time.Second).
 		Times(1)
 
-	dc := collector.NewWithClient(cli, mockClock, ignoreLabel)
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
 	# HELP docker_container_info Infos about the container
@@ -303,6 +303,10 @@ func buildContainerListResponse() []types.Container {
 			ID:    "testID",
 			Names: []string{"/testName"},
 			State: "running",
+			Labels: map[string]string{
+				"com.docker.compose.project": "web",
+				"maintainer":                 "acme",
+			},
 		},
 		{
 			ID:    "testIDIgnored",
@@ -424,4 +428,115 @@ func mockContainerStatsErrorDockerApi(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mockJsonResponse(w, r, buildContainerListResponse())
+}
+
+func TestCollectContainerLabels(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	srv := httptest.NewServer(http.HandlerFunc(mockDockerApi))
+	defer srv.Close()
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(srv.URL),
+		client.WithHTTPClient(&http.Client{}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	mockClock := mock.NewMockClock(ctrl)
+	mockClock.EXPECT().Now().Return(time.Now()).Times(1)
+	mockClock.EXPECT().
+		Parse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(s1, s2 string) (time.Time, error) {
+			return time.Parse(s1, s2)
+		}).
+		Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(1 * time.Second).Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(2 * time.Second).Times(1)
+
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, []string{
+		"com.docker.compose.project",
+		"unset",
+	})
+	// "unset" is not present on the container, so (kube_pod_labels style) it is
+	// simply omitted rather than exposed with an empty value. "maintainer" is
+	// present but not selected, so it is omitted too.
+	const expected = `
+	# HELP docker_container_labels Container labels converted to Prometheus labels
+	# TYPE docker_container_labels gauge
+	docker_container_labels{container_label_com_docker_compose_project="web",name="testName"} 1
+	`
+
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected), "docker_container_labels"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestCollectContainerLabelsFromContainerLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// A container opts specific labels in via the docker-exporter/exposed-labels
+	// label; no global keys are configured.
+	list := []types.Container{
+		{
+			ID:    "testID",
+			Names: []string{"/testName"},
+			State: "running",
+			Labels: map[string]string{
+				"com.docker.compose.project":     "web",
+				"maintainer":                     "acme",
+				"docker-exporter.exposed-labels": "maintainer",
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "stats"):
+			mockJsonResponse(w, r, buildStatsResponse())
+		case strings.Contains(r.URL.Path, "testID"):
+			mockJsonResponse(w, r, buildInspectResponse())
+		default:
+			mockJsonResponse(w, r, list)
+		}
+	}))
+	defer srv.Close()
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(srv.URL),
+		client.WithHTTPClient(&http.Client{}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	mockClock := mock.NewMockClock(ctrl)
+	mockClock.EXPECT().Now().Return(time.Now()).Times(1)
+	mockClock.EXPECT().
+		Parse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(s1, s2 string) (time.Time, error) {
+			return time.Parse(s1, s2)
+		}).
+		Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(1 * time.Second).Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(2 * time.Second).Times(1)
+
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
+
+	// Only "maintainer" was opted in; "com.docker.compose.project" is present
+	// but not selected.
+	const expected = `
+	# HELP docker_container_labels Container labels converted to Prometheus labels
+	# TYPE docker_container_labels gauge
+	docker_container_labels{container_label_maintainer="acme",name="testName"} 1
+	`
+
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected), "docker_container_labels"); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
 }

--- a/internal/collector/labels.go
+++ b/internal/collector/labels.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// exposedLabelsLabel is the container label whose comma-separated value selects
+// additional Docker label keys to expose for that specific container, on top of
+// any globally configured keys.
+const exposedLabelsLabel = "docker-exporter.exposed-labels"
+
+const containerLabelPrefix = "container_label_"
+
+var invalidLabelChar = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+// containerLabel maps a Docker label key to the sanitized Prometheus label name
+// it is exposed as.
+type containerLabel struct {
+	dockerKey string
+	promName  string
+}
+
+// sanitizeLabelName turns a Docker label key into a valid Prometheus label name
+// by prefixing it and replacing every invalid character with an underscore,
+// e.g. "com.docker.compose.project" -> "container_label_com_docker_compose_project".
+func sanitizeLabelName(key string) string {
+	return containerLabelPrefix + invalidLabelChar.ReplaceAllString(key, "_")
+}
+
+// buildContainerLabels resolves Docker label keys to unique Prometheus label
+// names, preserving order. Keys whose sanitized names collide get a
+// "_conflictN" suffix so the resulting names stay unique.
+func buildContainerLabels(keys []string) []containerLabel {
+	labels := make([]containerLabel, 0, len(keys))
+	seen := make(map[string]int, len(keys))
+
+	for _, key := range keys {
+		name := sanitizeLabelName(key)
+		if n := seen[name]; n > 0 {
+			seen[name] = n + 1
+			name = fmt.Sprintf("%s_conflict%d", name, n+1)
+		} else {
+			seen[name] = 1
+		}
+
+		labels = append(labels, containerLabel{dockerKey: key, promName: name})
+	}
+
+	return labels
+}
+
+// selectedLabelKeys returns the deduplicated Docker label keys to expose for a
+// container: the globally configured keys plus any listed in the container's
+// exposedLabelsLabel value.
+func (c *DockerCollector) selectedLabelKeys(container types.Container) []string {
+	seen := make(map[string]struct{})
+	keys := make([]string, 0, len(c.containerLabelKeys))
+
+	add := func(k string) {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return
+		}
+		if _, ok := seen[k]; ok {
+			return
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+
+	for _, k := range c.containerLabelKeys {
+		add(k)
+	}
+	if raw, ok := container.Labels[exposedLabelsLabel]; ok {
+		for _, k := range strings.Split(raw, ",") {
+			add(k)
+		}
+	}
+
+	return keys
+}
+
+// collectContainerLabels emits the docker_container_labels metric for a
+// container, exposing only the selected labels the container actually sets
+// (following the kube_pod_labels convention). It is a no-op when nothing is
+// selected or present, so every series carries a consistent, meaningful set.
+func (c *DockerCollector) collectContainerLabels(ch chan<- prometheus.Metric, name string, container types.Container) {
+	present := make([]string, 0)
+	for _, key := range c.selectedLabelKeys(container) {
+		if _, ok := container.Labels[key]; ok {
+			present = append(present, key)
+		}
+	}
+
+	if len(present) == 0 {
+		return
+	}
+
+	labels := buildContainerLabels(present)
+
+	names := make([]string, 0, len(labels)+1)
+	values := make([]string, 0, len(labels)+1)
+	names = append(names, "name")
+	values = append(values, name)
+	for _, l := range labels {
+		names = append(names, l.promName)
+		values = append(values, container.Labels[l.dockerKey])
+	}
+
+	desc := prometheus.NewDesc(
+		"docker_container_labels",
+		"Container labels converted to Prometheus labels",
+		names,
+		nil,
+	)
+
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1, values...)
+}

--- a/internal/collector/labels_test.go
+++ b/internal/collector/labels_test.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestBuildContainerLabels(t *testing.T) {
+	labels := buildContainerLabels([]string{
+		"com.docker.compose.project",
+		"my-label",
+		"a.b",
+		"a-b", // sanitizes to the same name as "a.b" -> conflict suffix
+	})
+
+	want := []containerLabel{
+		{dockerKey: "com.docker.compose.project", promName: "container_label_com_docker_compose_project"},
+		{dockerKey: "my-label", promName: "container_label_my_label"},
+		{dockerKey: "a.b", promName: "container_label_a_b"},
+		{dockerKey: "a-b", promName: "container_label_a_b_conflict2"},
+	}
+
+	if len(labels) != len(want) {
+		t.Fatalf("got %d labels, want %d: %+v", len(labels), len(want), labels)
+	}
+
+	for i, w := range want {
+		if labels[i] != w {
+			t.Errorf("label %d = %+v, want %+v", i, labels[i], w)
+		}
+	}
+}
+
+func TestSelectedLabelKeys(t *testing.T) {
+	c := &DockerCollector{containerLabelKeys: []string{"app", "team"}}
+	container := types.Container{
+		Labels: map[string]string{
+			// "team" duplicates a global key; whitespace and empty entries are
+			// trimmed/dropped.
+			exposedLabelsLabel: "team, project ,, role",
+		},
+	}
+
+	got := c.selectedLabelKeys(container)
+	want := []string{"app", "team", "project", "role"}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("key %d = %q, want %q", i, got[i], w)
+		}
+	}
+}


### PR DESCRIPTION
Closes #138.

## Summary

Adds an opt-in `docker_container_labels` metric (value `1`) that exposes a
container's Docker labels as Prometheus labels, following the `kube_pod_labels`
convention. Each series carries **only the selected labels the container
actually sets** — absent labels are omitted, not exported empty — so different
containers can expose different label sets in the same metric family (which
Prometheus and client_golang both tolerate for unchecked collectors).

## Selecting labels

Labels are opt-in via an allowlist. Two sources, combined as a **union**:

1. **Globally** for every container, via `--container-label` (repeatable) or a
   comma-separated `DOCKER_EXPORTER_CONTAINER_LABELS` env var:

   ```
   docker-exporter --container-label com.docker.compose.project --container-label maintainer
   ```

2. **Per container**, via the `docker-exporter.exposed-labels` label
   (comma-separated), matching the existing `docker-exporter.ignore` convention
   so a container can opt its own labels in without central config:

   ```yaml
   services:
     web:
       image: nginx
       labels:
         docker-exporter.exposed-labels: "com.docker.compose.project,maintainer"
   ```

Result:

```
docker_container_labels{name="web",container_label_com_docker_compose_project="shop",container_label_maintainer="acme"} 1
```

Join onto other metrics via the container `name`:

```promql
docker_container_cpu_usage_percentage
  * on(name) group_left(container_label_com_docker_compose_project) docker_container_labels
```

## Design notes

- **KSM-style, per-series label sets.** Unlike an empty-filled fixed schema,
  each series exposes only the labels present on that container — the same model
  as kube-state-metrics' `kube_pod_labels`. client_golang's `Gather` explicitly
  tolerates different label-name sets within a metric family, and the collector
  is unchecked (empty `Describe`), so no custom exposition layer is needed.
- **Sanitization:** `container_label_<key>`, `[^a-zA-Z0-9_]` -> `_`, with a
  `_conflictN` suffix on collisions.
- **Allowlist only.** Exporting *all* labels is intentionally not offered, to
  keep cardinality bounded. Note the per-container option delegates that choice
  to whoever can set container labels.
- Labels come from the existing `ContainerList` response — no extra Docker API
  call.

## Verification

- `gofmt`, `go vet ./...`, `golangci-lint run` (0 issues), `go build`.
- Unit tests: key sanitization + conflict suffixing; global/per-container key
  union + dedup.
- Behavioural tests (`testutil.CollectAndCompare`): global-flag selection and
  per-container `docker-exporter.exposed-labels` selection.
- `go test -race ./...` passes.
- Live smoke against two containers, one selected via the flag and one via its
  own label, each exposing a different label set:
  ```
  docker_container_labels{container_label_com_docker_compose_project="shop",name="de-a"} 1
  docker_container_labels{container_label_role="primary",name="de-b"} 1
  ```
