### PR TITLE
feat: add standards-compliant metrics, deprecate legacy names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,29 +66,51 @@ scrape_configs:
 
 ### Exported Metrics
 
-| Metric Name                                 | Description                        | Labels                  |
-| ------------------------------------------- | ---------------------------------- | ----------------------- |
-| docker_container_block_io_read_bytes        | Block I/O read bytes total         | name                    |
-| docker_container_block_io_write_bytes       | Block I/O write bytes total        | name                    |
-| docker_container_cpu_usage_percentage       | CPU usage in percentage            | name                    |
-| docker_container_info                       | Infos about the container          | name, image_name, image |
-| docker_container_labels                     | Configured container labels (value 1)  | name, container_label_* |
-| docker_container_memory_total_bytes         | Total memory in bytes              | name                    |
-| docker_container_memory_usage_bytes         | Memory usage in bytes              | name                    |
-| docker_container_memory_usage_percentage    | Memory usage in percentage         | name                    |
-| docker_container_network_rx_bytes           | Network received bytes total       | name, network           |
-| docker_container_network_rx_dropped_packets | Network dropped packets total      | name, network           |
-| docker_container_network_rx_errors          | Network received errors            | name, network           |
-| docker_container_network_rx_packets         | Network received packets total     | name, network           |
-| docker_container_network_tx_bytes           | Network sent bytes total           | name, network           |
-| docker_container_network_tx_dropped_packets | Network dropped packets total      | name, network           |
-| docker_container_network_tx_errors          | Network sent errors                | name, network           |
-| docker_container_network_tx_packets         | Network sent packets total         | name, network           |
-| docker_container_pids_current               | Current number of pids             | name                    |
-| docker_container_state                      | State of the container             | name, state             |
-| docker_container_uptime                     | Uptime of the container in seconds | name                    |
-| docker_exporter_scrape_duration             | Duration of the scrape in seconds  |                         |
-| docker_exporter_scrape_errors               | Number of scrape errors            |                         |
+| Metric Name | Type | Description | Labels |
+| --- | --- | --- | --- |
+| docker_container_cpu_usage_seconds_total | counter | Total CPU time consumed in seconds | name |
+| docker_container_cpu_online_cpus | gauge | Number of online CPUs | name |
+| docker_container_memory_usage_bytes | gauge | Memory usage in bytes | name |
+| docker_container_memory_limit_bytes | gauge | Memory limit in bytes | name |
+| docker_container_memory_usage_ratio | gauge | Memory usage as a ratio of the limit (0-1) | name |
+| docker_container_network_receive_bytes_total | counter | Total network bytes received | name, network |
+| docker_container_network_receive_packets_total | counter | Total network packets received | name, network |
+| docker_container_network_receive_packets_dropped_total | counter | Total network packets dropped while receiving | name, network |
+| docker_container_network_receive_errors_total | counter | Total network receive errors | name, network |
+| docker_container_network_transmit_bytes_total | counter | Total network bytes transmitted | name, network |
+| docker_container_network_transmit_packets_total | counter | Total network packets transmitted | name, network |
+| docker_container_network_transmit_packets_dropped_total | counter | Total network packets dropped while transmitting | name, network |
+| docker_container_network_transmit_errors_total | counter | Total network transmit errors | name, network |
+| docker_container_fs_reads_bytes_total | counter | Total bytes read from block devices | name |
+| docker_container_fs_writes_bytes_total | counter | Total bytes written to block devices | name |
+| docker_container_pids_current | gauge | Current number of pids | name |
+| docker_container_state | gauge | State of the container | name, state |
+| docker_container_uptime_seconds | gauge | Uptime of the container in seconds | name |
+| docker_container_info | gauge | Info about the container | name, image_name, image |
+| docker_container_labels | gauge | Configured container labels (value 1) | name, container_label_* |
+| docker_exporter_scrape_duration_seconds | gauge | Duration of the scrape in seconds | |
+| docker_exporter_scrape_errors_total | counter | Total number of scrape errors | |
+
+#### Deprecated metrics
+
+The schema was reworked to follow Prometheus naming conventions (counters end
+in `_total`, base units, ratios instead of percentages) and to expose
+cumulative values as proper counters. The previous metrics are **still emitted
+for backward compatibility** (with a deprecation note in their `HELP`) and will
+be removed in a future release. Migrate using this map:
+
+| Old | New |
+| --- | --- |
+| `docker_container_cpu_usage_percentage` (gauge) | `docker_container_cpu_usage_seconds_total` (counter) — use `rate(...)` |
+| `docker_container_memory_total_bytes` | `docker_container_memory_limit_bytes` |
+| `docker_container_memory_usage_percentage` (0-100) | `docker_container_memory_usage_ratio` (0-1) |
+| `docker_container_network_rx_*` (gauge) | `docker_container_network_receive_*_total` (counter) |
+| `docker_container_network_tx_*` (gauge) | `docker_container_network_transmit_*_total` (counter) |
+| `docker_container_block_io_read_bytes` (gauge) | `docker_container_fs_reads_bytes_total` (counter) |
+| `docker_container_block_io_write_bytes` (gauge) | `docker_container_fs_writes_bytes_total` (counter) |
+| `docker_container_uptime` | `docker_container_uptime_seconds` |
+| `docker_exporter_scrape_duration` | `docker_exporter_scrape_duration_seconds` |
+| `docker_exporter_scrape_errors` | `docker_exporter_scrape_errors_total` |
 
 ### Ignoring Containers
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -78,9 +78,16 @@ func (c *DockerCollector) Collect(ch chan<- prometheus.Metric) {
 		wg.Wait()
 	}
 
+	scrapeSeconds := c.clock.Since(now).Seconds()
+	ch <- prometheus.MustNewConstMetric(scrapeDurationSeconds,
+		prometheus.GaugeValue,
+		scrapeSeconds,
+	)
+
+	// Deprecated.
 	ch <- prometheus.MustNewConstMetric(scrapeDuration,
 		prometheus.GaugeValue,
-		c.clock.Since(now).Seconds(),
+		scrapeSeconds,
 	)
 }
 
@@ -118,9 +125,17 @@ func (c *DockerCollector) collectContainerMetrics(ctx context.Context, container
 		return
 	}
 
+	uptime := c.calculateUptime(inspect)
+	ch <- prometheus.MustNewConstMetric(containerUptimeSeconds,
+		prometheus.GaugeValue,
+		uptime,
+		name,
+	)
+
+	// Deprecated.
 	ch <- prometheus.MustNewConstMetric(containerUptime,
 		prometheus.GaugeValue,
-		c.calculateUptime(inspect),
+		uptime,
 		name,
 	)
 
@@ -140,18 +155,11 @@ func (c *DockerCollector) collectContainerMetrics(ctx context.Context, container
 }
 
 func (c *DockerCollector) cpuMetrics(ch chan<- prometheus.Metric, name string, stats *container.StatsResponse) {
-	cpuDelta := float64(stats.CPUStats.CPUUsage.TotalUsage) - float64(stats.PreCPUStats.CPUUsage.TotalUsage)
-	systemDelta := float64(stats.CPUStats.SystemUsage) - float64(stats.PreCPUStats.SystemUsage)
 	onlineCPUs := getOnlineCPUs(stats)
 
-	cpuPercent := 0.0
-	if systemDelta > 0.0 && cpuDelta > 0.0 {
-		cpuPercent = (cpuDelta / systemDelta) * onlineCPUs * 100.0
-	}
-
-	ch <- prometheus.MustNewConstMetric(cpuUsagePercentage,
-		prometheus.GaugeValue,
-		cpuPercent,
+	ch <- prometheus.MustNewConstMetric(cpuUsageSecondsTotal,
+		prometheus.CounterValue,
+		float64(stats.CPUStats.CPUUsage.TotalUsage)/1e9,
 		name,
 	)
 
@@ -160,18 +168,31 @@ func (c *DockerCollector) cpuMetrics(ch chan<- prometheus.Metric, name string, s
 		onlineCPUs,
 		name,
 	)
+
+	// Deprecated.
+	cpuDelta := float64(stats.CPUStats.CPUUsage.TotalUsage) - float64(stats.PreCPUStats.CPUUsage.TotalUsage)
+	systemDelta := float64(stats.CPUStats.SystemUsage) - float64(stats.PreCPUStats.SystemUsage)
+	cpuPercent := 0.0
+	if systemDelta > 0.0 && cpuDelta > 0.0 {
+		cpuPercent = (cpuDelta / systemDelta) * onlineCPUs * 100.0
+	}
+	ch <- prometheus.MustNewConstMetric(cpuUsagePercentage,
+		prometheus.GaugeValue,
+		cpuPercent,
+		name,
+	)
 }
 
 func (c *DockerCollector) memoryMetrics(ch chan<- prometheus.Metric, name string, stats *container.StatsResponse) {
 	mem := calculateMemUsageUnixNoCache(stats.MemoryStats)
 	memLimit := float64(stats.MemoryStats.Limit)
 
-	memPercent := 0.0
+	memRatio := 0.0
 	if memLimit > 0 {
-		memPercent = mem / memLimit * 100.0
+		memRatio = mem / memLimit
 	}
 
-	ch <- prometheus.MustNewConstMetric(memoryTotalBytes,
+	ch <- prometheus.MustNewConstMetric(memoryLimitBytes,
 		prometheus.GaugeValue,
 		memLimit,
 		name,
@@ -183,62 +204,62 @@ func (c *DockerCollector) memoryMetrics(ch chan<- prometheus.Metric, name string
 		name,
 	)
 
+	ch <- prometheus.MustNewConstMetric(memoryUsageRatio,
+		prometheus.GaugeValue,
+		memRatio,
+		name,
+	)
+
+	// Deprecated.
+	ch <- prometheus.MustNewConstMetric(memoryTotalBytes,
+		prometheus.GaugeValue,
+		memLimit,
+		name,
+	)
+
 	ch <- prometheus.MustNewConstMetric(memoryUsagePercentage,
 		prometheus.GaugeValue,
-		memPercent,
+		memRatio*100.0,
 		name,
 	)
 }
 
 func (c *DockerCollector) networkMetrics(ch chan<- prometheus.Metric, name string, stats *container.StatsResponse) {
 	for networkName, network := range stats.Networks {
+		ch <- prometheus.MustNewConstMetric(networkReceiveBytesTotal,
+			prometheus.CounterValue, float64(network.RxBytes), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkReceivePacketsTotal,
+			prometheus.CounterValue, float64(network.RxPackets), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkReceivePacketsDroppedTotal,
+			prometheus.CounterValue, float64(network.RxDropped), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkReceiveErrorsTotal,
+			prometheus.CounterValue, float64(network.RxErrors), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkTransmitBytesTotal,
+			prometheus.CounterValue, float64(network.TxBytes), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkTransmitPacketsTotal,
+			prometheus.CounterValue, float64(network.TxPackets), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkTransmitPacketsDroppedTotal,
+			prometheus.CounterValue, float64(network.TxDropped), name, networkName)
+		ch <- prometheus.MustNewConstMetric(networkTransmitErrorsTotal,
+			prometheus.CounterValue, float64(network.TxErrors), name, networkName)
+
+		// Deprecated.
 		ch <- prometheus.MustNewConstMetric(networkRxBytes,
-			prometheus.GaugeValue,
-			float64(network.RxBytes),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.RxBytes), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkRxPackets,
-			prometheus.GaugeValue,
-			float64(network.RxPackets),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.RxPackets), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkRxDroppedPackets,
-			prometheus.GaugeValue,
-			float64(network.RxDropped),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.RxDropped), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkRxErrors,
-			prometheus.GaugeValue,
-			float64(network.RxErrors),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.RxErrors), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkTxBytes,
-			prometheus.GaugeValue,
-			float64(network.TxBytes),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.TxBytes), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkTxPackets,
-			prometheus.GaugeValue,
-			float64(network.TxPackets),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.TxPackets), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkTxDroppedPackets,
-			prometheus.GaugeValue,
-			float64(network.TxDropped),
-			name, networkName,
-		)
-
+			prometheus.GaugeValue, float64(network.TxDropped), name, networkName)
 		ch <- prometheus.MustNewConstMetric(networkTxErrors,
-			prometheus.GaugeValue,
-			float64(network.TxErrors),
-			name, networkName,
-		)
+			prometheus.GaugeValue, float64(network.TxErrors), name, networkName)
 	}
 }
 
@@ -256,17 +277,16 @@ func (c *DockerCollector) blockIOMetrics(ch chan<- prometheus.Metric, name strin
 		}
 	}
 
-	ch <- prometheus.MustNewConstMetric(blockIOReadBytes,
-		prometheus.GaugeValue,
-		float64(blkRead),
-		name,
-	)
+	ch <- prometheus.MustNewConstMetric(fsReadsBytesTotal,
+		prometheus.CounterValue, float64(blkRead), name)
+	ch <- prometheus.MustNewConstMetric(fsWritesBytesTotal,
+		prometheus.CounterValue, float64(blkWrite), name)
 
+	// Deprecated.
+	ch <- prometheus.MustNewConstMetric(blockIOReadBytes,
+		prometheus.GaugeValue, float64(blkRead), name)
 	ch <- prometheus.MustNewConstMetric(blockIOWriteBytes,
-		prometheus.GaugeValue,
-		float64(blkWrite),
-		name,
-	)
+		prometheus.GaugeValue, float64(blkWrite), name)
 }
 
 func (c *DockerCollector) pidsMetrics(ch chan<- prometheus.Metric, name string, stats *container.StatsResponse) {
@@ -320,6 +340,8 @@ func (c *DockerCollector) isContainerIgnored(container types.Container) bool {
 }
 
 func (c *DockerCollector) collectScrapeError(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(scrapeErrorsTotal, prometheus.CounterValue, 1)
+	// Deprecated.
 	ch <- prometheus.MustNewConstMetric(scrapeErrors, prometheus.CounterValue, 1)
 }
 

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -63,69 +63,153 @@ func TestCollectMetrics(t *testing.T) {
 	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
-	# HELP docker_container_block_io_read_bytes Block I/O read bytes total
-	# TYPE docker_container_block_io_read_bytes gauge
-	docker_container_block_io_read_bytes{name="testName"} 9999
-	# HELP docker_container_block_io_write_bytes Block I/O write bytes total
-	# TYPE docker_container_block_io_write_bytes gauge
-	docker_container_block_io_write_bytes{name="testName"} 7777
 	# HELP docker_container_cpu_online_cpus Number of online CPUs
 	# TYPE docker_container_cpu_online_cpus gauge
 	docker_container_cpu_online_cpus{name="testName"} 4
-	# HELP docker_container_cpu_usage_percentage CPU usage in percentage
-	# TYPE docker_container_cpu_usage_percentage gauge
-	docker_container_cpu_usage_percentage{name="testName"} 0
+	# HELP docker_container_cpu_usage_seconds_total Total CPU time consumed in seconds
+	# TYPE docker_container_cpu_usage_seconds_total counter
+	docker_container_cpu_usage_seconds_total{name="testName"} 8.888e-06
+	# HELP docker_container_fs_reads_bytes_total Total bytes read from block devices
+	# TYPE docker_container_fs_reads_bytes_total counter
+	docker_container_fs_reads_bytes_total{name="testName"} 9999
+	# HELP docker_container_fs_writes_bytes_total Total bytes written to block devices
+	# TYPE docker_container_fs_writes_bytes_total counter
+	docker_container_fs_writes_bytes_total{name="testName"} 7777
 	# HELP docker_container_info Infos about the container
 	# TYPE docker_container_info gauge
 	docker_container_info{image="sha256:d3751d33f9cd5049c4af2b462735457e4d3baf130bcbb87f389e349fbaeb20b9",image_name="myImage",name="testName"} 1
-	# HELP docker_container_memory_total_bytes Total memory in bytes
-	# TYPE docker_container_memory_total_bytes gauge
-	docker_container_memory_total_bytes{name="testName"} 8e+09
+	# HELP docker_container_memory_limit_bytes Memory limit in bytes
+	# TYPE docker_container_memory_limit_bytes gauge
+	docker_container_memory_limit_bytes{name="testName"} 8e+09
 	# HELP docker_container_memory_usage_bytes Memory usage in bytes
 	# TYPE docker_container_memory_usage_bytes gauge
 	docker_container_memory_usage_bytes{name="testName"} 9999
-	# HELP docker_container_memory_usage_percentage Memory usage in percentage
-	# TYPE docker_container_memory_usage_percentage gauge
-	docker_container_memory_usage_percentage{name="testName"} 0.0001249875
-	# HELP docker_container_network_rx_bytes Network received bytes total
-	# TYPE docker_container_network_rx_bytes gauge
-	docker_container_network_rx_bytes{name="testName",network="eth0"} 135
-	# HELP docker_container_network_rx_dropped_packets Network dropped packets total
-	# TYPE docker_container_network_rx_dropped_packets gauge
-	docker_container_network_rx_dropped_packets{name="testName",network="eth0"} 3
-	# HELP docker_container_network_rx_errors Network received errors
-	# TYPE docker_container_network_rx_errors gauge
-	docker_container_network_rx_errors{name="testName",network="eth0"} 1
-	# HELP docker_container_network_rx_packets Network received packets total
-	# TYPE docker_container_network_rx_packets gauge
-	docker_container_network_rx_packets{name="testName",network="eth0"} 246
-	# HELP docker_container_network_tx_bytes Network sent bytes total
-	# TYPE docker_container_network_tx_bytes gauge
-	docker_container_network_tx_bytes{name="testName",network="eth0"} 975
-	# HELP docker_container_network_tx_dropped_packets Network dropped packets total
-	# TYPE docker_container_network_tx_dropped_packets gauge
-	docker_container_network_tx_dropped_packets{name="testName",network="eth0"} 2
-	# HELP docker_container_network_tx_errors Network sent errors
-	# TYPE docker_container_network_tx_errors gauge
-	docker_container_network_tx_errors{name="testName",network="eth0"} 4
-	# HELP docker_container_network_tx_packets Network sent packets total
-	# TYPE docker_container_network_tx_packets gauge
-	docker_container_network_tx_packets{name="testName",network="eth0"} 864
+	# HELP docker_container_memory_usage_ratio Memory usage as a ratio of the limit (0-1)
+	# TYPE docker_container_memory_usage_ratio gauge
+	docker_container_memory_usage_ratio{name="testName"} 1.249875e-06
+	# HELP docker_container_network_receive_bytes_total Total network bytes received
+	# TYPE docker_container_network_receive_bytes_total counter
+	docker_container_network_receive_bytes_total{name="testName",network="eth0"} 135
+	# HELP docker_container_network_receive_errors_total Total network receive errors
+	# TYPE docker_container_network_receive_errors_total counter
+	docker_container_network_receive_errors_total{name="testName",network="eth0"} 1
+	# HELP docker_container_network_receive_packets_dropped_total Total network packets dropped while receiving
+	# TYPE docker_container_network_receive_packets_dropped_total counter
+	docker_container_network_receive_packets_dropped_total{name="testName",network="eth0"} 3
+	# HELP docker_container_network_receive_packets_total Total network packets received
+	# TYPE docker_container_network_receive_packets_total counter
+	docker_container_network_receive_packets_total{name="testName",network="eth0"} 246
+	# HELP docker_container_network_transmit_bytes_total Total network bytes transmitted
+	# TYPE docker_container_network_transmit_bytes_total counter
+	docker_container_network_transmit_bytes_total{name="testName",network="eth0"} 975
+	# HELP docker_container_network_transmit_errors_total Total network transmit errors
+	# TYPE docker_container_network_transmit_errors_total counter
+	docker_container_network_transmit_errors_total{name="testName",network="eth0"} 4
+	# HELP docker_container_network_transmit_packets_dropped_total Total network packets dropped while transmitting
+	# TYPE docker_container_network_transmit_packets_dropped_total counter
+	docker_container_network_transmit_packets_dropped_total{name="testName",network="eth0"} 2
+	# HELP docker_container_network_transmit_packets_total Total network packets transmitted
+	# TYPE docker_container_network_transmit_packets_total counter
+	docker_container_network_transmit_packets_total{name="testName",network="eth0"} 864
 	# HELP docker_container_pids_current Current number of pids
 	# TYPE docker_container_pids_current gauge
 	docker_container_pids_current{name="testName"} 12
 	# HELP docker_container_state State of the container
 	# TYPE docker_container_state gauge
 	docker_container_state{name="testName",state="running"} 1
-	# HELP docker_container_uptime Uptime of the container in seconds
-	# TYPE docker_container_uptime gauge
-	docker_container_uptime{name="testName"} 1.0
-	# HELP docker_exporter_scrape_duration Duration of the scrape in seconds
-	# TYPE docker_exporter_scrape_duration gauge
-	docker_exporter_scrape_duration 2
+	# HELP docker_container_uptime_seconds Uptime of the container in seconds
+	# TYPE docker_container_uptime_seconds gauge
+	docker_container_uptime_seconds{name="testName"} 1.0
+	# HELP docker_exporter_scrape_duration_seconds Duration of the scrape in seconds
+	# TYPE docker_exporter_scrape_duration_seconds gauge
+	docker_exporter_scrape_duration_seconds 2
 	`
 
-	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected)); err != nil {
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected),
+		"docker_container_cpu_online_cpus",
+		"docker_container_cpu_usage_seconds_total",
+		"docker_container_fs_reads_bytes_total",
+		"docker_container_fs_writes_bytes_total",
+		"docker_container_info",
+		"docker_container_memory_limit_bytes",
+		"docker_container_memory_usage_bytes",
+		"docker_container_memory_usage_ratio",
+		"docker_container_network_receive_bytes_total",
+		"docker_container_network_receive_errors_total",
+		"docker_container_network_receive_packets_dropped_total",
+		"docker_container_network_receive_packets_total",
+		"docker_container_network_transmit_bytes_total",
+		"docker_container_network_transmit_errors_total",
+		"docker_container_network_transmit_packets_dropped_total",
+		"docker_container_network_transmit_packets_total",
+		"docker_container_pids_current",
+		"docker_container_state",
+		"docker_container_uptime_seconds",
+		"docker_exporter_scrape_duration_seconds",
+	); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}
+
+func TestCollectDeprecatedMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	srv := httptest.NewServer(http.HandlerFunc(mockDockerApi))
+	defer srv.Close()
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost(srv.URL),
+		client.WithHTTPClient(&http.Client{}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	mockClock := mock.NewMockClock(ctrl)
+	mockClock.EXPECT().Now().Return(time.Now()).Times(1)
+	mockClock.EXPECT().
+		Parse(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(s1, s2 string) (time.Time, error) {
+			return time.Parse(s1, s2)
+		}).
+		Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(1 * time.Second).Times(1)
+	mockClock.EXPECT().Since(gomock.Any()).Return(2 * time.Second).Times(1)
+
+	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
+
+	// The deprecated metrics are still emitted for backward compatibility.
+	const expected = `
+	# HELP docker_container_block_io_read_bytes Block I/O read bytes total (deprecated; use docker_container_fs_reads_bytes_total)
+	# TYPE docker_container_block_io_read_bytes gauge
+	docker_container_block_io_read_bytes{name="testName"} 9999
+	# HELP docker_container_cpu_usage_percentage CPU usage in percentage (deprecated; use docker_container_cpu_usage_seconds_total)
+	# TYPE docker_container_cpu_usage_percentage gauge
+	docker_container_cpu_usage_percentage{name="testName"} 0
+	# HELP docker_container_memory_total_bytes Total memory in bytes (deprecated; use docker_container_memory_limit_bytes)
+	# TYPE docker_container_memory_total_bytes gauge
+	docker_container_memory_total_bytes{name="testName"} 8e+09
+	# HELP docker_container_memory_usage_percentage Memory usage in percentage (deprecated; use docker_container_memory_usage_ratio)
+	# TYPE docker_container_memory_usage_percentage gauge
+	docker_container_memory_usage_percentage{name="testName"} 0.0001249875
+	# HELP docker_container_network_rx_bytes Network received bytes total (deprecated; use docker_container_network_receive_bytes_total)
+	# TYPE docker_container_network_rx_bytes gauge
+	docker_container_network_rx_bytes{name="testName",network="eth0"} 135
+	# HELP docker_container_uptime Uptime of the container in seconds (deprecated; use docker_container_uptime_seconds)
+	# TYPE docker_container_uptime gauge
+	docker_container_uptime{name="testName"} 1.0
+	`
+
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected),
+		"docker_container_block_io_read_bytes",
+		"docker_container_cpu_usage_percentage",
+		"docker_container_memory_total_bytes",
+		"docker_container_memory_usage_percentage",
+		"docker_container_network_rx_bytes",
+		"docker_container_uptime",
+	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -160,15 +244,18 @@ func TestCollectMetricsShouldCollectErrorWhenContainerListFails(t *testing.T) {
 	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
-	# HELP docker_exporter_scrape_errors Number of scrape errors
-	# TYPE docker_exporter_scrape_errors counter
-	docker_exporter_scrape_errors 1
-	# HELP docker_exporter_scrape_duration Duration of the scrape in seconds
-	# TYPE docker_exporter_scrape_duration gauge
-	docker_exporter_scrape_duration 2
+	# HELP docker_exporter_scrape_errors_total Total number of scrape errors
+	# TYPE docker_exporter_scrape_errors_total counter
+	docker_exporter_scrape_errors_total 1
+	# HELP docker_exporter_scrape_duration_seconds Duration of the scrape in seconds
+	# TYPE docker_exporter_scrape_duration_seconds gauge
+	docker_exporter_scrape_duration_seconds 2
 	`
 
-	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected)); err != nil {
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected),
+		"docker_exporter_scrape_errors_total",
+		"docker_exporter_scrape_duration_seconds",
+	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -203,15 +290,18 @@ func TestCollectMetricsShouldCollectErrorWhenContainerInspectFails(t *testing.T)
 	dc := collector.NewWithClient(cli, mockClock, ignoreLabel, nil)
 
 	const expected = `
-	# HELP docker_exporter_scrape_errors Number of scrape errors
-	# TYPE docker_exporter_scrape_errors counter
-	docker_exporter_scrape_errors 1
-	# HELP docker_exporter_scrape_duration Duration of the scrape in seconds
-	# TYPE docker_exporter_scrape_duration gauge
-	docker_exporter_scrape_duration 2
+	# HELP docker_exporter_scrape_errors_total Total number of scrape errors
+	# TYPE docker_exporter_scrape_errors_total counter
+	docker_exporter_scrape_errors_total 1
+	# HELP docker_exporter_scrape_duration_seconds Duration of the scrape in seconds
+	# TYPE docker_exporter_scrape_duration_seconds gauge
+	docker_exporter_scrape_duration_seconds 2
 	`
 
-	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected)); err != nil {
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected),
+		"docker_exporter_scrape_errors_total",
+		"docker_exporter_scrape_duration_seconds",
+	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }
@@ -266,18 +356,24 @@ func TestCollectMetricsShouldCollectErrorWhenContainerStatsFails(t *testing.T) {
 	# HELP docker_container_state State of the container
 	# TYPE docker_container_state gauge
 	docker_container_state{name="testName",state="running"} 1
-	# HELP docker_container_uptime Uptime of the container in seconds
-	# TYPE docker_container_uptime gauge
-	docker_container_uptime{name="testName"} 1
-	# HELP docker_exporter_scrape_duration Duration of the scrape in seconds
-	# TYPE docker_exporter_scrape_duration gauge
-	docker_exporter_scrape_duration 2
-	# HELP docker_exporter_scrape_errors Number of scrape errors
-	# TYPE docker_exporter_scrape_errors counter
-	docker_exporter_scrape_errors 1
+	# HELP docker_container_uptime_seconds Uptime of the container in seconds
+	# TYPE docker_container_uptime_seconds gauge
+	docker_container_uptime_seconds{name="testName"} 1
+	# HELP docker_exporter_scrape_duration_seconds Duration of the scrape in seconds
+	# TYPE docker_exporter_scrape_duration_seconds gauge
+	docker_exporter_scrape_duration_seconds 2
+	# HELP docker_exporter_scrape_errors_total Total number of scrape errors
+	# TYPE docker_exporter_scrape_errors_total counter
+	docker_exporter_scrape_errors_total 1
 	`
 
-	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected)); err != nil {
+	if err := testutil.CollectAndCompare(dc, strings.NewReader(expected),
+		"docker_container_info",
+		"docker_container_state",
+		"docker_container_uptime_seconds",
+		"docker_exporter_scrape_duration_seconds",
+		"docker_exporter_scrape_errors_total",
+	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -17,23 +17,23 @@ var (
 		nil,
 	)
 
-	containerUptime = prometheus.NewDesc(
-		"docker_container_uptime",
+	containerUptimeSeconds = prometheus.NewDesc(
+		"docker_container_uptime_seconds",
 		"Uptime of the container in seconds",
 		[]string{"name"},
 		nil,
 	)
 
-	scrapeDuration = prometheus.NewDesc(
-		"docker_exporter_scrape_duration",
+	scrapeDurationSeconds = prometheus.NewDesc(
+		"docker_exporter_scrape_duration_seconds",
 		"Duration of the scrape in seconds",
 		nil,
 		nil,
 	)
 
-	scrapeErrors = prometheus.NewDesc(
-		"docker_exporter_scrape_errors",
-		"Number of scrape errors",
+	scrapeErrorsTotal = prometheus.NewDesc(
+		"docker_exporter_scrape_errors_total",
+		"Total number of scrape errors",
 		nil,
 		nil,
 	)
@@ -42,9 +42,9 @@ var (
 		CPU Metrics
 	*/
 
-	cpuUsagePercentage = prometheus.NewDesc(
-		"docker_container_cpu_usage_percentage",
-		"CPU usage in percentage",
+	cpuUsageSecondsTotal = prometheus.NewDesc(
+		"docker_container_cpu_usage_seconds_total",
+		"Total CPU time consumed in seconds",
 		[]string{"name"},
 		nil,
 	)
@@ -67,16 +67,16 @@ var (
 		nil,
 	)
 
-	memoryTotalBytes = prometheus.NewDesc(
-		"docker_container_memory_total_bytes",
-		"Total memory in bytes",
+	memoryLimitBytes = prometheus.NewDesc(
+		"docker_container_memory_limit_bytes",
+		"Memory limit in bytes",
 		[]string{"name"},
 		nil,
 	)
 
-	memoryUsagePercentage = prometheus.NewDesc(
-		"docker_container_memory_usage_percentage",
-		"Memory usage in percentage",
+	memoryUsageRatio = prometheus.NewDesc(
+		"docker_container_memory_usage_ratio",
+		"Memory usage as a ratio of the limit (0-1)",
 		[]string{"name"},
 		nil,
 	)
@@ -85,76 +85,76 @@ var (
 		Network Metrics
 	*/
 
-	networkRxBytes = prometheus.NewDesc(
-		"docker_container_network_rx_bytes",
-		"Network received bytes total",
+	networkReceiveBytesTotal = prometheus.NewDesc(
+		"docker_container_network_receive_bytes_total",
+		"Total network bytes received",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkRxPackets = prometheus.NewDesc(
-		"docker_container_network_rx_packets",
-		"Network received packets total",
+	networkReceivePacketsTotal = prometheus.NewDesc(
+		"docker_container_network_receive_packets_total",
+		"Total network packets received",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkRxDroppedPackets = prometheus.NewDesc(
-		"docker_container_network_rx_dropped_packets",
-		"Network dropped packets total",
+	networkReceivePacketsDroppedTotal = prometheus.NewDesc(
+		"docker_container_network_receive_packets_dropped_total",
+		"Total network packets dropped while receiving",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkRxErrors = prometheus.NewDesc(
-		"docker_container_network_rx_errors",
-		"Network received errors",
+	networkReceiveErrorsTotal = prometheus.NewDesc(
+		"docker_container_network_receive_errors_total",
+		"Total network receive errors",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkTxBytes = prometheus.NewDesc(
-		"docker_container_network_tx_bytes",
-		"Network sent bytes total",
+	networkTransmitBytesTotal = prometheus.NewDesc(
+		"docker_container_network_transmit_bytes_total",
+		"Total network bytes transmitted",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkTxPackets = prometheus.NewDesc(
-		"docker_container_network_tx_packets",
-		"Network sent packets total",
+	networkTransmitPacketsTotal = prometheus.NewDesc(
+		"docker_container_network_transmit_packets_total",
+		"Total network packets transmitted",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkTxDroppedPackets = prometheus.NewDesc(
-		"docker_container_network_tx_dropped_packets",
-		"Network dropped packets total",
+	networkTransmitPacketsDroppedTotal = prometheus.NewDesc(
+		"docker_container_network_transmit_packets_dropped_total",
+		"Total network packets dropped while transmitting",
 		[]string{"name", "network"},
 		nil,
 	)
 
-	networkTxErrors = prometheus.NewDesc(
-		"docker_container_network_tx_errors",
-		"Network sent errors",
+	networkTransmitErrorsTotal = prometheus.NewDesc(
+		"docker_container_network_transmit_errors_total",
+		"Total network transmit errors",
 		[]string{"name", "network"},
 		nil,
 	)
 
 	/*
-		BlockIO Metrics
+		Filesystem (Block I/O) Metrics
 	*/
 
-	blockIOReadBytes = prometheus.NewDesc(
-		"docker_container_block_io_read_bytes",
-		"Block I/O read bytes total",
+	fsReadsBytesTotal = prometheus.NewDesc(
+		"docker_container_fs_reads_bytes_total",
+		"Total bytes read from block devices",
 		[]string{"name"},
 		nil,
 	)
 
-	blockIOWriteBytes = prometheus.NewDesc(
-		"docker_container_block_io_write_bytes",
-		"Block I/O write bytes total",
+	fsWritesBytesTotal = prometheus.NewDesc(
+		"docker_container_fs_writes_bytes_total",
+		"Total bytes written to block devices",
 		[]string{"name"},
 		nil,
 	)
@@ -167,6 +167,123 @@ var (
 		"docker_container_pids_current",
 		"Current number of pids",
 		[]string{"name"},
+		nil,
+	)
+)
+
+// Deprecated descriptors are kept for backward compatibility and emitted
+// alongside the standard metrics above. They will be removed in a future
+// release; prefer the replacements named in each help string.
+var (
+	cpuUsagePercentage = prometheus.NewDesc(
+		"docker_container_cpu_usage_percentage",
+		"CPU usage in percentage (deprecated; use docker_container_cpu_usage_seconds_total)",
+		[]string{"name"},
+		nil,
+	)
+
+	memoryTotalBytes = prometheus.NewDesc(
+		"docker_container_memory_total_bytes",
+		"Total memory in bytes (deprecated; use docker_container_memory_limit_bytes)",
+		[]string{"name"},
+		nil,
+	)
+
+	memoryUsagePercentage = prometheus.NewDesc(
+		"docker_container_memory_usage_percentage",
+		"Memory usage in percentage (deprecated; use docker_container_memory_usage_ratio)",
+		[]string{"name"},
+		nil,
+	)
+
+	networkRxBytes = prometheus.NewDesc(
+		"docker_container_network_rx_bytes",
+		"Network received bytes total (deprecated; use docker_container_network_receive_bytes_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkRxPackets = prometheus.NewDesc(
+		"docker_container_network_rx_packets",
+		"Network received packets total (deprecated; use docker_container_network_receive_packets_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkRxDroppedPackets = prometheus.NewDesc(
+		"docker_container_network_rx_dropped_packets",
+		"Network dropped packets total (deprecated; use docker_container_network_receive_packets_dropped_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkRxErrors = prometheus.NewDesc(
+		"docker_container_network_rx_errors",
+		"Network received errors (deprecated; use docker_container_network_receive_errors_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkTxBytes = prometheus.NewDesc(
+		"docker_container_network_tx_bytes",
+		"Network sent bytes total (deprecated; use docker_container_network_transmit_bytes_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkTxPackets = prometheus.NewDesc(
+		"docker_container_network_tx_packets",
+		"Network sent packets total (deprecated; use docker_container_network_transmit_packets_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkTxDroppedPackets = prometheus.NewDesc(
+		"docker_container_network_tx_dropped_packets",
+		"Network dropped packets total (deprecated; use docker_container_network_transmit_packets_dropped_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	networkTxErrors = prometheus.NewDesc(
+		"docker_container_network_tx_errors",
+		"Network sent errors (deprecated; use docker_container_network_transmit_errors_total)",
+		[]string{"name", "network"},
+		nil,
+	)
+
+	blockIOReadBytes = prometheus.NewDesc(
+		"docker_container_block_io_read_bytes",
+		"Block I/O read bytes total (deprecated; use docker_container_fs_reads_bytes_total)",
+		[]string{"name"},
+		nil,
+	)
+
+	blockIOWriteBytes = prometheus.NewDesc(
+		"docker_container_block_io_write_bytes",
+		"Block I/O write bytes total (deprecated; use docker_container_fs_writes_bytes_total)",
+		[]string{"name"},
+		nil,
+	)
+
+	containerUptime = prometheus.NewDesc(
+		"docker_container_uptime",
+		"Uptime of the container in seconds (deprecated; use docker_container_uptime_seconds)",
+		[]string{"name"},
+		nil,
+	)
+
+	scrapeDuration = prometheus.NewDesc(
+		"docker_exporter_scrape_duration",
+		"Duration of the scrape in seconds (deprecated; use docker_exporter_scrape_duration_seconds)",
+		nil,
+		nil,
+	)
+
+	scrapeErrors = prometheus.NewDesc(
+		"docker_exporter_scrape_errors",
+		"Number of scrape errors (deprecated; use docker_exporter_scrape_errors_total)",
+		nil,
 		nil,
 	)
 )


### PR DESCRIPTION
## Summary

Introduces a Prometheus-conventions metric schema **alongside** the existing
metrics. The old metrics are **kept and marked deprecated** (via their `HELP`),
so existing dashboards and alerts keep working. They'll be removed in a future
release. Non-breaking.

## Why

- Cumulative values (network, block I/O) were exported as **gauges** despite
  being monotonic — the new ones are proper **counters**.
- CPU was only a precomputed percentage gauge; the cumulative counter cAdvisor
  and `rate()` expect was missing.
- Percentages violate Prometheus conventions (base units / ratios); counters
  should end in `_total`.

## New metrics

- Counters (`_total`): `cpu_usage_seconds_total`, `network_receive_*` /
  `network_transmit_*` (bytes/packets/packets_dropped/errors),
  `fs_reads_bytes_total` / `fs_writes_bytes_total`, `scrape_errors_total`.
- Gauges: `memory_limit_bytes`, `memory_usage_ratio` (0-1), `uptime_seconds`,
  `scrape_duration_seconds`.
- Names are cAdvisor-aligned (`receive`/`transmit`, `fs_*`) so cAdvisor
  dashboards can be reached via simple relabeling (partially addresses #94).

## Backward compatibility

Every previous metric is still emitted, unchanged in name/type/value, with a
`(deprecated; use <new>)` suffix in its `HELP`. New and legacy series are
exported together. Full old→new map is in the README.

> Trade-off: emitting both roughly doubles the affected series. A flag to
> disable the deprecated set can be added if desired.

## Verification

- `gofmt`, `go vet ./...`, `golangci-lint run` (0 issues), `go build`.
- Tests: new-schema exposition asserted via filtered `CollectAndCompare`; a
  dedicated test asserts the deprecated families still emit with their old
  names/types/values. `go test -race ./...` passes.
- Fixed two latent double-computations surfaced by dual-emit (uptime and scrape
  duration were computed twice).
- Live smoke: new and legacy metrics coexist with matching values, e.g.
  `cpu_usage_seconds_total` + `cpu_usage_percentage`, `network_receive_bytes_total`
  + `network_rx_bytes`, `fs_reads_bytes_total` + `block_io_read_bytes`.
