### PR TITLE
feat(metrics): add container exit_code, restarts_total and health

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ scrape_configs:
 | docker_container_state | gauge | State of the container | name, state |
 | docker_container_exit_code | gauge | Exit code of the container's last run (meaningful when not running) | name |
 | docker_container_restarts_total | counter | Total container restarts by the restart policy | name |
-| docker_container_health | gauge | Health-check status (value 1 for the current status; absent without a HEALTHCHECK) | name, status |
+| docker_container_health | gauge | Health-check status (value 1 for the current status; `none` when no HEALTHCHECK) | name, status |
 | docker_container_uptime_seconds | gauge | Uptime of the container in seconds | name |
 | docker_container_info | gauge | Info about the container | name, image_name, image |
 | docker_container_labels | gauge | Configured container labels (value 1) | name, container_label_* |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ scrape_configs:
 | docker_container_fs_writes_bytes_total | counter | Total bytes written to block devices | name |
 | docker_container_pids_current | gauge | Current number of pids | name |
 | docker_container_state | gauge | State of the container | name, state |
+| docker_container_exit_code | gauge | Exit code of the container's last run (meaningful when not running) | name |
+| docker_container_restarts_total | counter | Total container restarts by the restart policy | name |
+| docker_container_health | gauge | Health-check status (value 1 for the current status; absent without a HEALTHCHECK) | name, status |
 | docker_container_uptime_seconds | gauge | Uptime of the container in seconds | name |
 | docker_container_info | gauge | Info about the container | name, image_name, image |
 | docker_container_labels | gauge | Configured container labels (value 1) | name, container_label_* |

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -131,11 +131,13 @@ func (c *DockerCollector) collectContainerMetrics(ctx context.Context, container
 		containerRestartsTotal, prometheus.CounterValue, float64(inspect.RestartCount), name,
 	)
 
+	health := types.NoHealthcheck
 	if inspect.State.Health != nil {
-		ch <- prometheus.MustNewConstMetric(
-			containerHealth, prometheus.GaugeValue, 1, name, inspect.State.Health.Status,
-		)
+		health = inspect.State.Health.Status
 	}
+	ch <- prometheus.MustNewConstMetric(
+		containerHealth, prometheus.GaugeValue, 1, name, health,
+	)
 
 	if container.State != "running" {
 		return

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -121,6 +121,22 @@ func (c *DockerCollector) collectContainerMetrics(ctx context.Context, container
 		containerStateMetric, prometheus.GaugeValue, 1, name, container.State,
 	)
 
+	// Lifecycle/status (from inspect, available for every state — emitted before
+	// the running-only block so stopped/restarting containers are still covered).
+	ch <- prometheus.MustNewConstMetric(
+		containerExitCode, prometheus.GaugeValue, float64(inspect.State.ExitCode), name,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		containerRestartsTotal, prometheus.CounterValue, float64(inspect.RestartCount), name,
+	)
+
+	if inspect.State.Health != nil {
+		ch <- prometheus.MustNewConstMetric(
+			containerHealth, prometheus.GaugeValue, 1, name, inspect.State.Health.Status,
+		)
+	}
+
 	if container.State != "running" {
 		return
 	}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -114,6 +114,15 @@ func TestCollectMetrics(t *testing.T) {
 	# HELP docker_container_pids_current Current number of pids
 	# TYPE docker_container_pids_current gauge
 	docker_container_pids_current{name="testName"} 12
+	# HELP docker_container_exit_code Exit code of the container's last run (meaningful when the container is not running)
+	# TYPE docker_container_exit_code gauge
+	docker_container_exit_code{name="testName"} 137
+	# HELP docker_container_health Container health-check status (value 1 for the current status; absent when no HEALTHCHECK is defined)
+	# TYPE docker_container_health gauge
+	docker_container_health{name="testName",status="healthy"} 1
+	# HELP docker_container_restarts_total Total number of times the container has been restarted by its restart policy
+	# TYPE docker_container_restarts_total counter
+	docker_container_restarts_total{name="testName"} 3
 	# HELP docker_container_state State of the container
 	# TYPE docker_container_state gauge
 	docker_container_state{name="testName",state="running"} 1
@@ -143,6 +152,9 @@ func TestCollectMetrics(t *testing.T) {
 		"docker_container_network_transmit_packets_dropped_total",
 		"docker_container_network_transmit_packets_total",
 		"docker_container_pids_current",
+		"docker_container_exit_code",
+		"docker_container_health",
+		"docker_container_restarts_total",
 		"docker_container_state",
 		"docker_container_uptime_seconds",
 		"docker_exporter_scrape_duration_seconds",
@@ -381,8 +393,11 @@ func TestCollectMetricsShouldCollectErrorWhenContainerStatsFails(t *testing.T) {
 func buildInspectResponse() types.ContainerJSON {
 	return types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{
+			RestartCount: 3,
 			State: &types.ContainerState{
 				StartedAt: "2023-09-17T12:00:00.00Z",
+				ExitCode:  137,
+				Health:    &types.Health{Status: "healthy"},
 			},
 			Image: "sha256:d3751d33f9cd5049c4af2b462735457e4d3baf130bcbb87f389e349fbaeb20b9",
 		},

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -117,7 +117,7 @@ func TestCollectMetrics(t *testing.T) {
 	# HELP docker_container_exit_code Exit code of the container's last run (meaningful when the container is not running)
 	# TYPE docker_container_exit_code gauge
 	docker_container_exit_code{name="testName"} 137
-	# HELP docker_container_health Container health-check status (value 1 for the current status; absent when no HEALTHCHECK is defined)
+	# HELP docker_container_health Container health-check status (value 1 for the current status; 'none' when no HEALTHCHECK is defined)
 	# TYPE docker_container_health gauge
 	docker_container_health{name="testName",status="healthy"} 1
 	# HELP docker_container_restarts_total Total number of times the container has been restarted by its restart policy

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -26,7 +26,7 @@ var (
 
 	containerHealth = prometheus.NewDesc(
 		"docker_container_health",
-		"Container health-check status (value 1 for the current status; absent when no HEALTHCHECK is defined)",
+		"Container health-check status (value 1 for the current status; 'none' when no HEALTHCHECK is defined)",
 		[]string{"name", "status"},
 		nil,
 	)

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -10,6 +10,27 @@ var (
 		nil,
 	)
 
+	containerExitCode = prometheus.NewDesc(
+		"docker_container_exit_code",
+		"Exit code of the container's last run (meaningful when the container is not running)",
+		[]string{"name"},
+		nil,
+	)
+
+	containerRestartsTotal = prometheus.NewDesc(
+		"docker_container_restarts_total",
+		"Total number of times the container has been restarted by its restart policy",
+		[]string{"name"},
+		nil,
+	)
+
+	containerHealth = prometheus.NewDesc(
+		"docker_container_health",
+		"Container health-check status (value 1 for the current status; absent when no HEALTHCHECK is defined)",
+		[]string{"name", "status"},
+		nil,
+	)
+
 	containerInfo = prometheus.NewDesc(
 		"docker_container_info",
 		"Infos about the container",


### PR DESCRIPTION
## What
Expose three container status metrics from the already-fetched `inspect` (no extra Docker API call), following the schema-v2 conventions:

| Metric | Type | Labels |
| --- | --- | --- |
| `docker_container_exit_code` | gauge | name |
| `docker_container_restarts_total` | counter | name |
| `docker_container_health` | gauge | name, status |

`docker_container_health` is a state-set (value 1 for the current status), emitted only when the container defines a HEALTHCHECK. All three are emitted before the running-only block, so stopped/restarting containers are covered.

## Why
Enables the missing container-lifecycle alerts: crash-loop (`increase(docker_container_restarts_total[15m])`), non-zero exit (`docker_container_state{state="exited"} == 1 and on(name) docker_container_exit_code != 0`) and unhealthy (`docker_container_health{status="unhealthy"} == 1`).

## Not included
OOM: `inspect` only exposes a transient `OOMKilled` bool, not derivable as a reliable counter (cAdvisor's `container_oom_events_total` needs the event stream).

## Testing
`gofmt -l` clean, `go build ./...`, `go vet`, `go test ./...` all pass (collector + handler).